### PR TITLE
BUGFIX Wotlk doens't have name specs

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -4213,7 +4213,8 @@ do
         local n = #info
         local spec, option = info[1], info[n]
 
-        spec = specIDByName[ spec ]
+        if type( spec ) == 'string' then spec = specIDByName[ spec ] end
+  
         if not spec then return end
 
         if type( val ) == 'string' then val = val:trim() end
@@ -4233,7 +4234,7 @@ do
         local n = #info
         local spec, option = info[1], info[n]
 
-        spec = specIDByName[ spec ]
+        if type( spec ) == 'string' then spec = specIDByName[ spec ] end
         if not spec then return end
 
         self.DB.profile.specs[ spec ] = self.DB.profile.specs[ spec ] or {}


### PR DESCRIPTION
This patch makes the function Set/GetSpecOption working in wotlk.

I used those functions to create WA to see the status of multiple settings (flowerweaving / bearweaving / bearweaving spell) and toggle them directly by clicking on the WA.